### PR TITLE
Generalize bold/italics sequence to arbitrary prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ To insert a bold character the '&#92;mbf\<character\>'  can be used. For instanc
 
 If a sequence of characters needs to be bolded or italicised then the following sequences will work:
 '&#92;b:matrix' or '&#92;i:matrix' resulting in '𝐦𝐚𝐭𝐫𝐢𝐱' and '𝑚𝑎𝑡𝑟𝑖𝑥'.
+
+## Special
+
+You can also convert a list of chars with special prefix via \prefix:abc, which
+will be equivalent to \prefixa \prefixb and \prefixc, for example:
+
+\Bbb:ABCabc → 𝔸𝔹ℂ𝕒𝕓𝕔

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,7 @@ class UnicodeMaths {
         else if (startch === '^') { return this.mapToSubSup(word, sups); }
         else if (word.startsWith('\\i:')) { return this.mapToBoldIt(word, false); }
         else if (word.startsWith('\\b:')) { return this.mapToBoldIt(word, true); }
-        else if (word.startsWith('\\') && word.includes(':')) { return this.mapTo(word); }
+        else if (!word.startsWith('\\:') && word.startsWith('\\') && word.includes(':')) { return this.mapTo(word); }
         return this.codes[word] || null;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,8 @@ class UnicodeMaths {
         else if (startch === '^') { return this.mapToSubSup(word, sups); }
         else if (word.startsWith('\\i:')) { return this.mapToBoldIt(word, false); }
         else if (word.startsWith('\\b:')) { return this.mapToBoldIt(word, true); }
-        return this.codes[word] || null; 
+        else if (word.startsWith('\\') && word.includes(':')) { return this.mapTo(word); }
+        return this.codes[word] || null;
     }
 
     private mapToSubSup(word: string, mapper: {[key: string]: string}): string | null {        
@@ -116,6 +117,17 @@ class UnicodeMaths {
         const newstr = target.split('').map((c: string) => this.codes[codeprfx + c] || c).join('');
         this.debug('mapToBoldIt word: ', word, 'bold:', bold, 'newstr:', newstr);
         return newstr === target ? null : newstr;
+    }
+
+    private mapTo(word: string): string | null {
+        const modifier = word.split(':');
+        if (modifier.length === 2) {
+            const mod    = modifier[0];
+            const newstr = modifier[1];
+            const modstr = newstr.split('').map((c: string) => this.codes[mod + c] || c).join('');
+            return modstr === word ? null : modstr;
+        }
+        return null;
     }
 
     private debug(msg: any, ...optionals: any[]) {


### PR DESCRIPTION
The Sublime text version of this extension supports conversion of lists of chars with special prefixes via \\prefix\abc.
Part of this is implemented here via `\b:matrix` and `\i:matrix`. Those are limited to `\mbf` and `\mit`, however.

This patch lifts this restriction and introduces the new syntax `\prefix:abc`, which will be equivalent to \prefixa \prefixb and \prefixc, for example:
\Bbb:ABCabc → 𝔸𝔹ℂ𝕒𝕓𝕔
