### PR TITLE
Disable keybindings if editor language is set to 'latex'. Fixes #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
 			{
 				"command": "unicode-math-vscode.commit_tab",
 				"key": "tab",
-                "when": "editorTextFocus && !inlineSuggestionVisible && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !editorTabMovesFocus && !editorReadonly"
+                "when": "editorTextFocus && !inlineSuggestionVisible && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !editorTabMovesFocus && !editorReadonly && !editorLangId != 'latex'"
 			},
 			{
 				"command": "unicode-math-vscode.commit_space",
 				"key": "space",
-                "when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !editorTabMovesFocus && !editorReadonly"
+                "when": "editorTextFocus && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !editorTabMovesFocus && !editorReadonly && !editorLangId != 'latex'"
 			}
 		]
 	},


### PR DESCRIPTION
Fixes #11 

It would be great to also disable the extension when in markdown math mode, but it's not clear to me how to achieve that.